### PR TITLE
Use stable version of the multipart stream builder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": ">=5.5",
         "laravie/codex": "~0.4.2 || ~0.5",
-        "php-http/multipart-stream-builder": "^0.1.1"
+        "php-http/multipart-stream-builder": "^1.0"
     },
     "require-dev": {
         "php-http/guzzle6-adapter": "^1.0",


### PR DESCRIPTION
There is one thing that might be considered as a BC break. If we, for whatever reason, added multiple streams/post data with the same name. Before they were overridden but since 0.2.0 we do allow duplicate values. 
